### PR TITLE
Vagrant 1.8.4 compatibility

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -4,7 +4,7 @@ source "https://rubygems.org"
 gemspec
 
 group :development do
-  gem "vagrant", git: "https://github.com/mitchellh/vagrant.git", ref: "v1.7.4"
+  gem "vagrant", git: "https://github.com/mitchellh/vagrant.git", ref: "v1.8.4"
 end
 
 group :plugins do

--- a/lib/vagrant-winrm-syncedfolders/synced_folder.rb
+++ b/lib/vagrant-winrm-syncedfolders/synced_folder.rb
@@ -23,7 +23,7 @@ module VagrantPlugins
         folders.each do |_id, data|
           hostpath  = File.expand_path(data[:hostpath], machine.env.root_path)
           guestpath = data[:guestpath]
-          sync machine, hostpath, guestpath
+          sync machine, hostpath.to_s, guestpath
         end
       end
 

--- a/lib/vagrant-winrm-syncedfolders/version.rb
+++ b/lib/vagrant-winrm-syncedfolders/version.rb
@@ -1,5 +1,5 @@
 module VagrantPlugins
   module SyncedFolderWinRM
-    VERSION = "1.0.0"
+    VERSION = "1.0.1".freeze
   end
 end

--- a/vagrant-winrm-syncedfolders.gemspec
+++ b/vagrant-winrm-syncedfolders.gemspec
@@ -17,10 +17,6 @@ Gem::Specification.new do |spec|
   spec.test_files    = spec.files.grep(%r{^(test|spec|features)/})
   spec.require_paths = ["lib"]
 
-  # 0.2.0 bundled with vagrant 1.7.4 has a known bug
-  # we can force this dependency as a stop-gap [GH-3]
-  spec.add_runtime_dependency "winrm-fs", "~> 0.2.2"
-
   spec.add_development_dependency "bundler", "~> 1.6"
   spec.add_development_dependency "rake", "~> 10.0"
   spec.add_development_dependency "rspec", "~> 2.14"


### PR DESCRIPTION
Attempt to address #8.

Remove dependency spec for winrm-fs. Bump version to 1.0.1.

I have been unable to test because vagrant 1.8.4 refuses to install local gem (works in 1.8.1). Is there any other way to install non-published plugin?
